### PR TITLE
ci: Claude Code Review が問題なしでも明示コメントを残す

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,17 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # 注: 変数は github.repository（リポジトリ名）と pull_request.number（数値）のみ。
+          # 攻撃者制御の自由文（issue/PR タイトル・本文等）は使用しないため injection リスクなし。
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            レビュー完了後、指摘の有無にかかわらず PR に総括コメントを必ず 1 件投稿すること。
+            コメント先頭に判定行を置く:
+            - 問題なし: 「✅ Claude Code Review: 問題なし（LGTM）」+ 確認した観点を 3〜5 行で要約
+            - 指摘あり: 「🔧 Claude Code Review: <件数> 件の指摘」+ 各指摘の要約
+            目的は「問題がない場合でもレビューが実行され合格したことが PR 上で明示的に分かる」ようにすること。
+            これを最優先で遵守する。
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## 背景

Claude Code Review（`claude-code-review.yml`）はレビューを `code-review` スキルに丸投げしており、指摘がゼロのときは PR にコメントを投稿しない既定挙動だった。そのため:

- **「レビューが走って問題なし」なのか「レビューが落ちて未実行」なのか PR 画面で区別できない**
- マージ判断時に「コメントが無い＝大丈夫だろう」という暗黙の推測に依存していた

## 変更

`prompt` に後置指示を追加し、**指摘の有無にかかわらず総括コメントを必ず 1 件投稿**させる:

- 問題なし → `✅ Claude Code Review: 問題なし（LGTM）` + 確認した観点を 3〜5 行
- 指摘あり → `🔧 Claude Code Review: <件数> 件の指摘` + 各指摘の要約

`code-review` スキルの構造化レビュー品質はそのまま活かし、最後の総括コメントだけを強制する最小変更。

## セキュリティ

prompt の変数は `github.repository`（リポジトリ名）と `github.event.pull_request.number`（数値）のみ。攻撃者制御の自由文（issue/PR タイトル・本文等）は不使用のため command injection リスクなし（ワークフローにコメントで明記）。

## 確認方法

この PR 自体で Claude Code Review が走り、**問題なしなら ✅ コメントが付く**ことで動作確認できる（＝本 PR がドッグフーディング）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
